### PR TITLE
Bugfix: Put fontSize in the right place in kicker block.json

### DIFF
--- a/blocks/kicker/block.json
+++ b/blocks/kicker/block.json
@@ -12,7 +12,9 @@
 	"supports": {
 		"html": false,
 		"customClassName": false,
-		"fontSize": true
+		"typography" : {
+			"fontSize": true
+		}
 	},
 	"attributes": {
 		"content": {


### PR DESCRIPTION
Fixes this warning:

<img width="594" alt="Screen Shot 2021-07-21 at 1 49 33 PM" src="https://user-images.githubusercontent.com/226381/126536053-7dd19b95-5107-48ff-9881-df2bbc16695c.png">
