### PR TITLE
Remove product logging

### DIFF
--- a/blocks/products/includes/renderer.php
+++ b/blocks/products/includes/renderer.php
@@ -25,9 +25,6 @@ function products_block_render_callback( $block_attributes) {
 		$url_hash = wp_hash( $block_attributes['query_url'] );
 	}
 
-	error_log( '$url_hash' );
-	error_log( $url_hash );
-
 	if ( empty( $url_hash ) ) {
 		return;
 	} else {

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.1
+ * Version:     0.5.2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issue(s)
- closes #23 

### Accomplished
- Remove accidentally leftover debug logging
- Bumps vers num to `0.5.2`