### PR TITLE
Issue#22/kicker text transform issue

### DIFF
--- a/blocks/kicker/build/block.json
+++ b/blocks/kicker/build/block.json
@@ -33,9 +33,10 @@
 		},
 		"style": {
 			"type": "object",
-			"default": {
-				"typography": {
-					"textTransform": "uppercase"
+			"typography": {
+				"textTransform": {
+					"type": "string",
+					"default": "uppercase"
 				}
 			}
 		}

--- a/blocks/kicker/src/block.json
+++ b/blocks/kicker/src/block.json
@@ -33,9 +33,10 @@
 		},
 		"style": {
 			"type": "object",
-			"default": {
-				"typography": {
-					"textTransform": "uppercase"
+			"typography": {
+				"textTransform": {
+					"type": "string",
+					"default": "uppercase"
 				}
 			}
 		}

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.3-beta01
+ * Version:     0.5.3-beta02
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.2
+ * Version:     0.5.3-beta01
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.3-beta02
+ * Version:     0.5.3
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.2",
+	"version": "0.5.3-beta01",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.3-beta02",
+	"version": "0.5.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.3-beta01",
+	"version": "0.5.3-beta02",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.3-beta01",
+	"version": "0.5.3-beta02",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.2",
+	"version": "0.5.3-beta01",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.3-beta02",
+	"version": "0.5.3",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/patterns/trivia/trivia.php
+++ b/patterns/trivia/trivia.php
@@ -13,6 +13,6 @@ register_block_pattern(
 		'title'       => __( 'Trivia', 'cata' ),
 		'categories'  => array( 'text' ),
 		'description' => _x( 'Trivia question pattern. An aside containing a title, question and answer.', 'Block pattern description', 'cata' ),
-		'content'     => "<!-- wp:cata/aside -->\n<aside class=\"wp-block-cata-aside\">\n<div class=\"wp-block-cata-aside__inner-container\">\n<!-- wp:cata/kicker {\"fontSize\":\"small\"} -->\n<p class=\"wp-block-cata-kicker has-small-font-size\" style=\"text-transform:uppercase;\">Trivia Question</p>\n<!-- /wp:cata/kicker -->\n<!-- wp:paragraph -->\n<p><strong>Question:</strong> Question here?</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p><strong>Answer:</strong> <span class=\"tap-reveal\">Answer here</span></p>\n<!-- /wp:paragraph -->\n</div>\n</aside>\n<!-- /wp:cata/aside -->\n",
+		'content'     => "<!-- wp:cata/aside -->\n<aside class=\"wp-block-cata-aside\">\n<div class=\"wp-block-cata-aside__inner-container\">\n<!-- wp:cata/kicker {\"fontSize\":\"small\", \"style\":{ \"typography\":{\"textTransform\":\"uppercase\"}}} -->\n<p class=\"wp-block-cata-kicker has-small-font-size\" style=\"text-transform:uppercase;\">Trivia Question</p>\n<!-- /wp:cata/kicker -->\n<!-- wp:paragraph -->\n<p><strong>Question:</strong> Question here?</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p><strong>Answer:</strong> <span class=\"tap-reveal\">Answer here</span></p>\n<!-- /wp:paragraph -->\n</div>\n</aside>\n<!-- /wp:cata/aside -->\n",
 	)
 );


### PR DESCRIPTION
### Related issues
- Closes #22 

### What was accomplished
- Simple restructuring of the `style` block attribute in the `block.json` file:
  - Changed the default value from wrapping the `typography` and `textTransform` properties to instead being a property of `textTransform`
  - added a `type` property for `textTransform`

### Testing
- [x] locally
- [x] [staging (on ThoughtNet)](https://thoughtcatalog-network-develop.go-vip.net/creepycatalog/kicker-block-debug-test/)

### Open Questions
Previously, the `kicker` block would cause a validation error if it was saved with no text transformation set, and when a user attempted a block recovery, it would reset to having an uppercase transformation even though it was previously set with none. Now, this does not occur though there is an error kicked out to the console:
<img width="1450" alt="Screen Shot 2022-04-29 at 12 16 08 PM" src="https://user-images.githubusercontent.com/40250614/165987115-5139fcbd-be81-4402-a2bd-f167e05cb7b0.png">
![Screen Shot 2022-04-29 at 12 16 39 PM](https://user-images.githubusercontent.com/40250614/165987118-fa939f68-607e-4cb3-955d-58c0d3786dd1.png)

Whats particularly interesting here is that this error is coming from the `trivia question` block pattern [where it registers the trivia block pattern](https://github.com/thoughtis/cata-blocks/blob/e550d17b4672f95d7ebe5b6d09c53b13aeb0a217/patterns/trivia/trivia.php#L16) even when the block is not included in the actual post content. Additionally, though there is an error in the console, the pattern behaves normally and correctly and the post content can be updated, the post viewed on the front end, and reloaded in the editor without any issues OTHER than the console error.

I think that the pattern seems to be saving the kicker block in a way that matches what a default kicker block looks like, I am experimenting with how the trivia question pattern is written, to see if it can be alleviated without affecting functionality at all.