### PR TITLE
Hotfix/products block byline classname

### DIFF
--- a/blocks/products/build/block.json
+++ b/blocks/products/build/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/blocks/products/includes/renderer.php
+++ b/blocks/products/includes/renderer.php
@@ -105,7 +105,7 @@ function render_product( stdClass $product , bool $display_byline) : string {
  * @return string
  */
 function render_byline( stdClass $product ) : string {
-	$byline_start = '<div class=\"wp-block-cata-product__byline\">';
+	$byline_start = '<div class=wp-block-cata-product__byline>';
 	$byline_end   = '</div>';
 
 	if ( is_array( $product->cap_guest_authors ) && ! empty( $product->cap_guest_authors ) ) {

--- a/blocks/products/products.php
+++ b/blocks/products/products.php
@@ -4,7 +4,7 @@
  * Description:       Dynamic Block which renders a block of Shop Catalog Products.
  * Requires at least: 5.8
  * Requires PHP:      7.0
- * Version:           0.2.1
+ * Version:           0.2.2
  * Author:            The WordPress Contributors
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/blocks/products/src/block.json
+++ b/blocks/products/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.5
+ * Version:     0.5.6
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
- Small hotfix which removes now unneeded escaping slashes and double quotes from product byline class name.