### PR TITLE
Issue#30/block editor product links

### DIFF
--- a/blocks/products/build/block.json
+++ b/blocks/products/build/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.3-beta01",
+	"version": "0.2.3",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/blocks/products/build/block.json
+++ b/blocks/products/build/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.2",
+	"version": "0.2.3-beta01",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/blocks/products/build/index.asset.php
+++ b/blocks/products/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-api-fetch', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '2c8c2024026a4f986760a215f6c4acf2');
+<?php return array('dependencies' => array('wp-api-fetch', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '53801ba24b2a648560126bd82cc316d5');

--- a/blocks/products/build/index.css
+++ b/blocks/products/build/index.css
@@ -1,1 +1,1 @@
-.wp-block-cata-products-fetch-btn{-webkit-margin-end:.75em;margin-inline-end:.75em}
+.wp-block-cata-products-fetch-btn{-webkit-margin-end:.75em;margin-inline-end:.75em}.wp-block-cata-product__link{pointer-events:none}

--- a/blocks/products/products.php
+++ b/blocks/products/products.php
@@ -4,7 +4,7 @@
  * Description:       Dynamic Block which renders a block of Shop Catalog Products.
  * Requires at least: 5.8
  * Requires PHP:      7.0
- * Version:           0.2.3-beta01
+ * Version:           0.2.3
  * Author:            The WordPress Contributors
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/blocks/products/products.php
+++ b/blocks/products/products.php
@@ -4,7 +4,7 @@
  * Description:       Dynamic Block which renders a block of Shop Catalog Products.
  * Requires at least: 5.8
  * Requires PHP:      7.0
- * Version:           0.2.2
+ * Version:           0.2.3-beta01
  * Author:            The WordPress Contributors
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/blocks/products/src/block.json
+++ b/blocks/products/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.3-beta01",
+	"version": "0.2.3",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/blocks/products/src/block.json
+++ b/blocks/products/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "cata/products",
-	"version": "0.2.2",
+	"version": "0.2.3-beta01",
 	"title": "Shop Catalog Products",
 	"category": "widgets",
 	"icon": "store",

--- a/blocks/products/src/editor.scss
+++ b/blocks/products/src/editor.scss
@@ -7,3 +7,7 @@
 .wp-block-cata-products-fetch-btn {
 	margin-inline-end: 0.75em;
 }
+
+.wp-block-cata-product__link {
+	pointer-events: none;
+}

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.7-beta01
+ * Version:     0.5.7
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.5.6
+ * Version:     0.5.7-beta01
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.6",
+	"version": "0.5.7-beta01",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.7-beta01",
+	"version": "0.5.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.7-beta01",
+	"version": "0.5.7",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.5.6",
+	"version": "0.5.7-beta01",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issue
- Closes #30 

### Accomplishes
- Adds `pointer-events: none` to `.wp-block-cata-product__link` via `editor.scss` so it only affects links displayed in the block editor. Links rendered on the front end are unaffected.

### Testing
- [x] Locally
- [ ] staging (via thoughtNet)