### PR TITLE
Decode HTML entities in URL before cache hashing

### DIFF
--- a/blocks/products/includes/feed/cache/class-cache.php
+++ b/blocks/products/includes/feed/cache/class-cache.php
@@ -58,8 +58,8 @@ class Cache {
 	 * @param string $url
 	 */
 	public function __construct( string $url ) {
-		$this->url = $url;
-		$this->hash = wp_hash( $url );
+		$this->url  = html_entity_decode( $url );
+		$this->hash = wp_hash( $this->url );
 		$this->data_key = self::$data_key_base . $this->hash;
 		$this->time_key = self::$time_key_base . $this->hash;
 		$this->duration = HOUR_IN_SECONDS;


### PR DESCRIPTION
### Related Issues
- Resolves #36 

### What Was Accomplished
- Updated the constructor for `Cata\Blocks\Products\Feed\Cache` to apply `html_entity_decode` to the URL before hashing it for use as a cache key.

### How It Was Tested
- [x] Local plugin dev site ( issue was not present, but change didn't create any new problems )
- [x] Remote site with cata child theme ( corrected issue )