### PR TITLE
Issue#38/wp next scheduled

### DIFF
--- a/blocks/products/includes/feed/class-feed.php
+++ b/blocks/products/includes/feed/class-feed.php
@@ -72,14 +72,19 @@ class Feed {
 
 	/**
 	 * Set Update Schedule
+	 * If no event is scheduled, schedule one.
 	 */
 	public function set_update_schedule() : void {
+		$options = array(
+			'url' => $this->url
+		);
+		if ( false !== wp_next_scheduled( Feed\Update::ACTION, $options ) ) {
+			return;
+		}
 		wp_schedule_single_event(
 			time(),
 			Feed\Update::ACTION,
-			array(
-				'url' => $this->url
-			)
+			$options
 		);
 	}
 

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.6.1
+ * Version:     0.6.2-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.6.1",
+	"version": "0.6.2-beta1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.6.1",
+	"version": "0.6.2-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #38 

### What Was Accomplished
- Added a check on `wp_next_scheduled` before scheduling an event to prevent re-scheduling in the brief period between scheduling and execution.

### How It Was Tested
- [x] Local plugin development environment
- [x] Remote environment using cata child theme

### How To Verify in Production
- [ ] No new `WordPress database error Duplicate entry` in logs.