### PR TITLE
Issue#63/opt out components

### DIFF
--- a/blocks/aside/aside.php
+++ b/blocks/aside/aside.php
@@ -11,6 +11,9 @@ namespace Cata\Blocks;
  * Register Aside Block
  */
 function register_aside_block() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+	if ( ! apply_filters( 'cata_blocks_support_aside_block', true ) ) {
+		return;
+	}
+	register_block_type( __DIR__ . '/build' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_aside_block' );

--- a/blocks/kicker/kicker.php
+++ b/blocks/kicker/kicker.php
@@ -11,6 +11,9 @@ namespace Cata\Blocks;
  * Register Kicker block
  */
 function register_kicker_block() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+	if ( ! apply_filters( 'cata_blocks_support_kicker_block', true ) ) {
+		return;
+	}
+	register_block_type( __DIR__ . '/build' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_kicker_block' );

--- a/blocks/newsletter/newsletter.php
+++ b/blocks/newsletter/newsletter.php
@@ -1,15 +1,8 @@
 <?php
 /**
- * Plugin Name:       Newsletter Form
- * Description:       Example block written with ESNext standard and JSX support – build step required.
- * Requires at least: 5.8
- * Requires PHP:      7.0
- * Version:           0.1.0
- * Author:            The WordPress Contributors
- * License:           GPL-2.0-or-later
- * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Newsletter
  *
- * @package           Cata\Blocks
+ * @package Cata\Blocks
  */
 
 namespace Cata\Blocks;
@@ -21,8 +14,11 @@ use Cata\Blocks\Newsletter\Renderer;
  *
  * @return void
  */
-function register_newsletter_block() {
-	register_block_type_from_metadata(
+function register_newsletter_block() : void {
+	if ( ! apply_filters( 'cata_blocks_support_newsletter_block', true ) ) {
+		return;
+	}
+	register_block_type(
 		__DIR__ . '/build',
 		array(
 			'render_callback' => __NAMESPACE__ . '\\render_newsletter_block'

--- a/blocks/products/products.php
+++ b/blocks/products/products.php
@@ -15,6 +15,9 @@ namespace Cata\Blocks;
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function init_products_block() {
+	if ( ! apply_filters( 'cata_blocks_support_products_block', true ) ) {
+		return;
+	}
 	register_block_type(
 		__DIR__ . '/build',
 		array(

--- a/blocks/table-of-contents/table-of-contents.php
+++ b/blocks/table-of-contents/table-of-contents.php
@@ -1,16 +1,8 @@
 <?php
 /**
- * Plugin Name:       Table Of Contents
- * Description:       Example block written with ESNext standard and JSX support – build step required.
- * Requires at least: 5.8
- * Requires PHP:      7.0
- * Version:           0.1.0
- * Author:            The WordPress Contributors
- * License:           GPL-2.0-or-later
- * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       table-of-contents
+ * Table Of Contents
  *
- * @package           Cata\Blocks
+ * @package Cata\Blocks
  */
 
 namespace Cata\Blocks;
@@ -20,10 +12,12 @@ namespace Cata\Blocks;
  *
  * @return void
  */
-function register_toc_block() {
-	register_block_type_from_metadata( __DIR__ . '/build' );
+function register_toc_block() : void {
+	if ( ! apply_filters( 'cata_blocks_support_table-of-contents_block', true ) ) {
+		return;
+	}
+	register_block_type( __DIR__ . '/build' );
 }
-
 add_action( 'init', __NAMESPACE__ . '\\register_toc_block' );
 
 /**

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.7.2-beta1
+ * Version:     0.7.2-beta2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/formats/overhang/overhang.php
+++ b/formats/overhang/overhang.php
@@ -13,7 +13,10 @@ defined( 'ABSPATH' ) || exit;
  * Registers all block assets so that they can be enqueued through Gutenberg in
  * the corresponding context.
  */
-add_action( 'init', function() {
+function register_overhang_format() {
+	if ( ! apply_filters( 'cata_blocks_support_overhang_format', true ) ) {
+		return;
+	}
 	// Automatically load dependencies and version.
 	$asset_file = include plugin_dir_path( __FILE__ ) . 'build/index.asset.php';
 
@@ -24,14 +27,13 @@ add_action( 'init', function() {
 		$asset_file['version'],
 		true
 	);
-} );
+	add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_overhang_format_assets' );
+}
+add_action( 'init', __NAMESPACE__ . '\\register_overhang_format' );
 
 /**
- * Enqueue block editor assets for this example.
+ * Enqueue Overhang Format Assets
  */
-add_action(
-	'enqueue_block_editor_assets',
-	function() {
-		wp_enqueue_script( 'cata-block-editor-format-overhang' );
-	}
-);
+function enqueue_overhang_format_assets() {
+	wp_enqueue_script( 'cata-block-editor-format-overhang' );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.7.2-beta1",
+	"version": "0.7.2-beta2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.7.2-beta1",
+			"version": "0.7.2-beta2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.7.2-beta1",
+	"version": "0.7.2-beta2",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/patterns/trivia/trivia.php
+++ b/patterns/trivia/trivia.php
@@ -7,12 +7,21 @@
 
 namespace Cata\Blocks;
 
-register_block_pattern(
-	'cata/trivia',
-	array(
-		'title'       => __( 'Trivia', 'cata' ),
-		'categories'  => array( 'text' ),
-		'description' => _x( 'Trivia question pattern. An aside containing a title, question and answer.', 'Block pattern description', 'cata' ),
-		'content'     => "<!-- wp:cata/aside -->\n<aside class=\"wp-block-cata-aside\">\n<div class=\"wp-block-cata-aside__inner-container\">\n<!-- wp:cata/kicker {\"fontSize\":\"small\", \"style\":{ \"typography\":{\"textTransform\":\"uppercase\"}}} -->\n<p class=\"wp-block-cata-kicker has-small-font-size\" style=\"text-transform:uppercase;\">Trivia Question</p>\n<!-- /wp:cata/kicker -->\n<!-- wp:paragraph -->\n<p><strong>Question:</strong> Question here?</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p><strong>Answer:</strong> <span class=\"tap-reveal\">Answer here</span></p>\n<!-- /wp:paragraph -->\n</div>\n</aside>\n<!-- /wp:cata/aside -->\n",
-	)
-);
+/**
+ * Register Trivia Pattern
+ */
+function register_trivia_pattern() : void {
+	if ( ! apply_filters( 'cata_blocks_support_trivia_pattern', true ) ) {
+		return;
+	}
+	register_block_pattern(
+		'cata/trivia',
+		array(
+			'title'       => __( 'Trivia', 'cata' ),
+			'categories'  => array( 'text' ),
+			'description' => _x( 'Trivia question pattern. An aside containing a title, question and answer.', 'Block pattern description', 'cata' ),
+			'content'     => "<!-- wp:cata/aside -->\n<aside class=\"wp-block-cata-aside\">\n<div class=\"wp-block-cata-aside__inner-container\">\n<!-- wp:cata/kicker {\"fontSize\":\"small\", \"style\":{ \"typography\":{\"textTransform\":\"uppercase\"}}} -->\n<p class=\"wp-block-cata-kicker has-small-font-size\" style=\"text-transform:uppercase;\">Trivia Question</p>\n<!-- /wp:cata/kicker -->\n<!-- wp:paragraph -->\n<p><strong>Question:</strong> Question here?</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p><strong>Answer:</strong> <span class=\"tap-reveal\">Answer here</span></p>\n<!-- /wp:paragraph -->\n</div>\n</aside>\n<!-- /wp:cata/aside -->\n",
+		)
+	);	
+}
+add_action( 'init', __NAMESPACE__ . '\\register_trivia_pattern' );


### PR DESCRIPTION
### Related Issues
- Resolves #63 
- Includes changes from #62 which should be merged before this.

### What Was Accomplished
- Updated all blocks, formats and patterns to provide a filter following the pattern `cata_blocks_support_${name}_${type}` to them to be turned off.

### How It Was Tested
- [x] Plugin dev site
- [x] Local theme dev site

### How To Test
- [x] Adding `add_filter('cata_blocks_support_newsletter_block', '__return_false');` to the active theme's functions file prevents the newsletter block from being available in the editor.