### PR TITLE
Enable "generateAnchors" setting in block editor when table of contents block is supported

### DIFF
--- a/blocks/table-of-contents/table-of-contents.php
+++ b/blocks/table-of-contents/table-of-contents.php
@@ -17,6 +17,7 @@ function register_toc_block() : void {
 		return;
 	}
 	register_block_type( __DIR__ . '/build' );
+	add_filter( 'block_editor_settings_all', __NAMESPACE__ . '\\enabled_generate_anchors' );
 }
 add_action( 'init', __NAMESPACE__ . '\\register_toc_block' );
 
@@ -66,4 +67,20 @@ function conditionally_remove_script() : void {
 	}
 	wp_dequeue_script( 'cata-toc-script' );
 }
-add_action( 'wp_enqueue_scripts', __NAMESPACE__. '\\conditionally_remove_script' ); 
+add_action( 'wp_enqueue_scripts', __NAMESPACE__. '\\conditionally_remove_script' );
+
+/**
+ * Enable Generate Anchors
+ *
+ * @link https://github.com/WordPress/gutenberg/pull/38780#issuecomment-1122412396
+ * @param array $settings
+ * @return array
+ */
+function enabled_generate_anchors( array $settings ) : array {			
+	return array_merge(
+		$settings,
+		array(
+			'generateAnchors' => true,
+		)
+	);
+}

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.7.3
+ * Version:     0.7.4-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */


### PR DESCRIPTION
### Relate Issues
- #12 

### What Was Accomplished
- Updated the registration of the Table of Contents block to add a filter on `block_editor_settings_all`
- Added function `enabled_generate_anchors` to set `generateAnchors=true` in the block editor settings.

### How It Was Tested
- [x] Local plugin dev site
- [x] Local theme dev site

### How To Test
- [x] Ids are generated for headings, as shown in the screenshots below
- [x] Once an id is generated, you can edit the id, and further edits to the heading text will not change the id

### Open Questions
- This doesn't fully solve the issue because we're not abe to turn off our script that handles ids. I think the remaining task would involve generating anchors all existing Tables of Contents.

### Screenshots

#### Auto generated id
<img width="932" alt="Screen Shot 2022-12-15 at 9 30 47 AM" src="https://user-images.githubusercontent.com/226381/207890583-3fbc36ac-c852-429d-8194-d6b8dd416a1c.png">

#### Auto generated id that I edited

<img width="917" alt="Screen Shot 2022-12-15 at 9 30 36 AM" src="https://user-images.githubusercontent.com/226381/207890748-c77beb67-5ab1-442c-a604-b95c1e9cc68e.png">

