### PR TITLE
Expand function arguments in Shopify block's `do_scheduled_update`

### DIFF
--- a/blocks/shopify/includes/feed/query/class-query.php
+++ b/blocks/shopify/includes/feed/query/class-query.php
@@ -13,13 +13,41 @@ namespace Cata\Blocks\Shopify\Feed;
  */
 class Query {
 	/**
+	 * Default Options
+	 * The block attributes that are used to query Shopify.
+	 *
+	 * @var array
+	 */
+	const DEFAULT_OPTIONS = array(
+		'store' => '',
+		'tags'  => '',
+		'count' => 0,
+	);
+
+	/**
+	 * Options
+	 * 
+	 * @var array $options
+	 */
+	public array $options;
+
+	/**
 	 * Construct
 	 * 
 	 * @param string $store
 	 */
-	public function __construct(
-		public array $options
-	) {}
+	public function __construct( array $options ) {
+		// Before setting options:
+		// Apply allow-list using keys from DEFAULT_OPTIONS,
+		// Merge to ensure keys are always in the same order.
+		$this->options = array_merge(
+			self::DEFAULT_OPTIONS,
+			array_intersect_key(
+				$options,
+				self::DEFAULT_OPTIONS
+			)
+		);
+	}
 
 	/**
 	 * Get URL

--- a/blocks/shopify/includes/feed/update/class-update.php
+++ b/blocks/shopify/includes/feed/update/class-update.php
@@ -19,7 +19,7 @@ class Update {
 	 * Construct
 	 */
 	public function __construct() {
-		add_action( self::ACTION, array( __CLASS__, 'do_scheduled_update' ), 10, 2 );
+		add_action( self::ACTION, array( __CLASS__, 'do_scheduled_update' ), 10, 3 );
 	}
 
 	/**
@@ -27,8 +27,12 @@ class Update {
 	 *
 	 * @param array $options
 	 */
-	public static function do_scheduled_update( array $options ) : void {
-		$query = new Query( $options );
+	public static function do_scheduled_update( string $store, string $tags, int $count ) : void {
+		$query = new Query( array(
+			'store' => $store,
+			'tags'  => $tags,
+			'count' => $count
+		) );
 		$cache = new Cache( $query );
 		$fetch = new Fetch( $query );
 

--- a/blocks/shopify/shopify.php
+++ b/blocks/shopify/shopify.php
@@ -8,6 +8,8 @@
 
 namespace Cata\Blocks;
 
+use Throwable;
+
 /**
  * Register Shopify Block
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.8.4
+ * Version:     0.8.5
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.4",
+	"version": "0.8.5-beta1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.8.4",
+			"version": "0.8.5-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.5-beta1",
+	"version": "0.8.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.8.5-beta1",
+			"version": "0.8.5",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.5-beta1",
+	"version": "0.8.5",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.4",
+	"version": "0.8.5-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #111 

### What Was Accomplished
- Updated `do_scheduled_update` so the function arguments include the three paramaters we need to query Shopify.
- Updated `Query` PHP class to reduce the `$options` variable to only the options we need, and ensure the are in the same order they are used for `do_scheduled_update`.