### PR TITLE
Make nullable parameters in Layout class required but still nullable

### DIFF
--- a/blocks/rest/includes/layout/class-layout.php
+++ b/blocks/rest/includes/layout/class-layout.php
@@ -53,7 +53,7 @@ abstract class Layout {
 	 * @param stdClass|null $image
 	 * @param float|null $aspect_ratio 
 	 */
-	public static function get_image_dimensions( ?stdClass $image = null, ?float $aspect_ratio = null, array $target_widths ) : array {
+	public static function get_image_dimensions( stdClass|null $image, float|null $aspect_ratio, array $target_widths ) : array {
 		if ( null === $image ) {
 			return [[0,0]];
 		}
@@ -91,7 +91,7 @@ abstract class Layout {
 	 * @param array $options
 	 * @return string
 	 */
-	public static function render_image( ?stdClass $image = null, array $options ) : string {
+	public static function render_image( stdClass|null $image, array $options ) : string {
 		if ( null === $image ) {
 			return '';
 		}

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.8.13
+ * Version:     0.8.14-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.8.14-beta1
+ * Version:     0.8.14
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.13",
+	"version": "0.8.14-beta1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.8.13",
+			"version": "0.8.14-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.14-beta1",
+	"version": "0.8.14",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.8.14-beta1",
+			"version": "0.8.14",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.13",
+	"version": "0.8.14-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.8.14-beta1",
+	"version": "0.8.14",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #125 

### What Was Accomplished
- Update function signatures in the Layout class to use the union type `stdClass|null` instead of an optional parameter. The parameters are required and they can be `null`.
  - If there is no image data available for a post returned by the WP REST API then these image related functions could be passed a null value, but a value is always passed.

### How It Was Tested
- [x] Local
- [x] Development / staging

### How To Test
- Create a post with a REST Block, when viewing the post no warnings about optional parameter ordering are thrown.

### References

I had to refresh my memory about nullable vs optional.

- The types `?string` and `string|null` are identical.
- `string|null $name` is nullable because of the union type.
- `string|null $name = ''` is optional since it has a default value, it can't go before a required parameter.

https://www.php.net/manual/en/functions.arguments.php
https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.nullable