### PR TITLE
Issue#148/product block filter

### DIFF
--- a/blocks/shopify/includes/render/class-render.php
+++ b/blocks/shopify/includes/render/class-render.php
@@ -53,7 +53,7 @@ class Render {
 	 */
 	public static function render_product( stdClass $product, bool $display_price ) : string {
 		$title = esc_html( $product->title );
-		$href  = esc_url( $product->onlineStoreUrl );
+		$href  = esc_url( apply_filters( 'cata_product_block_link', $product->onlineStoreUrl ) );
 		$price = true === $display_price ? self::wrap_price( self::render_price( $product->priceRange ) ) : '';
 		$image = self::render_image(
 			$product,

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.9.1
+ * Version:     0.9.2-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.9.2-beta1
+ * Version:     0.9.2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.9.2-beta1",
+	"version": "0.9.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.9.2-beta1",
+			"version": "0.9.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.9.1",
+	"version": "0.9.2-beta1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.9.1",
+			"version": "0.9.2-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "^8.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.9.1",
+	"version": "0.9.2-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.9.2-beta1",
+	"version": "0.9.2",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Closes #148 

### What Was Accomplished
- Added a call to the `cata_product_block_link` filter on the Shopify block

### How It Was Tested
- [x] Locally on child theme

### How To Test
- New & existing Shopify blocks on any Thoughtnet child theme have UTMs added to the end of each product URL

### Deploy Steps
- Make an issue and merge to Thoughtnet
- Make an issue to add a filter and deploy to Thought Catalog