### PR TITLE
In REST API block, open links to other domains in new tab

### DIFF
--- a/blocks/rest/includes/layout/class-layout.php
+++ b/blocks/rest/includes/layout/class-layout.php
@@ -124,13 +124,7 @@ abstract class Layout {
 			$attributes['class'] = esc_attr( $options['class'] );
 		}
 
-		$attributes_string = implode( ' ', array_map(
-			function( $key, $value ) {
-				return "{$key}=\"{$value}\"";
-			},
-			array_keys($attributes), 
-			array_values($attributes)
-		) );
+		$attributes_string = self::render_attribute_string( $attributes );
 
 		return "<img {$attributes_string}>";
 	}
@@ -173,7 +167,46 @@ abstract class Layout {
 					$src
 				)
 			);
-			return "${resized_src} {$set[0]}w";
+			return "{$resized_src} {$set[0]}w";
 		};
+	}
+
+	/**
+	 * Render Link
+	 * 
+	 * @param string $href
+	 * @param string $content
+	 * @param null|array $other_attributes
+	 */
+	public static function render_link( string $href, string $content, ?array $other_attributes = array() ): string {
+
+		$attributes = array(
+			...$other_attributes,
+			'href' => $href,
+		);
+
+		if ( ! str_starts_with( $href, home_url() ) ) {
+			$attributes['target'] = '_blank';
+		}
+
+		$attributes_string = self::render_attribute_string( $attributes );
+
+		return "<a {$attributes_string}>{$content}</a>";
+	}
+
+	/**
+	 * Render Attribute String
+	 *
+	 * @param array $attributes
+	 */
+	public static function render_attribute_string( array $attributes ): string {
+		return implode(
+			' ',
+			array_map(
+				fn( $key, $value ) => "{$key}=\"{$value}\"",
+				array_keys($attributes),
+				array_values($attributes)
+			)
+		);
 	}
 }

--- a/blocks/rest/includes/layout/compact/class-compact.php
+++ b/blocks/rest/includes/layout/compact/class-compact.php
@@ -52,7 +52,7 @@ class Compact extends Layout {
 	 */
 	public static function render_preview( stdClass $post ) : string {
 		$title  = esc_html( $post->title->rendered );
-		$link   = esc_url( $post->link );
+		$href   = esc_url( $post->link );
 		$image_data = self::get_image( $post );
 		$image = self::render_image(
 			$image_data,
@@ -62,18 +62,19 @@ class Compact extends Layout {
 			)
 		);
 
+		$image_link = self::render_link( $href, $image );
+		$title_link = self::render_link( $href, $title, ['rel' => 'bookmark', 'class' => 'preview_permalink'] );
+
 		return "<article class=\"preview is-layout-compact\">
 			<div class=\"preview__layout\">
 				<div class=\"preview__start\">
 					<figure class=\"preview__image-container\">
-						<a rel=\"bookmark\" href=\"{$link}\">
-							{$image}
-						</a>
+						{$image_link}
 					</figure>
 				</div>
 				<div class=\"preview__end\">
 					<h3 class=\"preview__title\">
-						<a class=\"preview__permalink\" rel=\"bookmark\" href=\"{$link}\">{$title}</a>
+						{$title_link}
 					</h3>
 				</div>
 			</div>

--- a/blocks/rest/includes/layout/daily-horoscope/class-daily-horoscope.php
+++ b/blocks/rest/includes/layout/daily-horoscope/class-daily-horoscope.php
@@ -50,9 +50,6 @@ class Daily_Horoscope extends Layout {
 	public static function render_preview( stdClass $post, bool $display_zodiac_links ): string {
 		$date         = date_create( $post->date );
 		$date         = esc_html( date_format( $date, 'l, F j, Y' ) );
-		$link         = esc_url( $post->link );
-		$excerpt      = wp_kses_post( $post->excerpt->rendered );
-		$domain       = wp_parse_url( $post->link, PHP_URL_HOST );
 		$zodiac_links = $display_zodiac_links ? self::get_zodiac_links( $post ) : '';
 
 		return "<article class=\"preview is-layout-daily-horoscope\">
@@ -92,11 +89,11 @@ class Daily_Horoscope extends Layout {
 	 * 
 	 * @param string $anchor
 	 * @param string $text
-	 * @param string $link
+	 * @param string $href
 	 * @return string
 	 */
-	public static function get_zodiac_link( string $anchor, string $text, string $link ): string {
-		$link     = esc_url( $link );
+	public static function get_zodiac_link( string $anchor, string $text, string $href ): string {
+		$href     = esc_url( $href );
 		$anchor   = esc_attr( $anchor );
 		$text     = esc_html( wp_strip_all_tags( $text ) );
 		$svg_path = __DIR__ . "/svg/$anchor.svg";
@@ -106,7 +103,9 @@ class Daily_Horoscope extends Layout {
 			return '';
 		}
 
-		return "<li><a href=\"{$link}#{$anchor}\">{$symbol}{$text}</a></li>";
+		$link = self::render_link( "{$href}#{$anchor}", "{$symbol}{$text}" );
+
+		return "<li>{$link}</li>";
 	}
 
 	/**

--- a/blocks/rest/includes/layout/network/class-network.php
+++ b/blocks/rest/includes/layout/network/class-network.php
@@ -59,25 +59,24 @@ class Network extends Layout {
 			)
 		);
 
-		$link    = esc_url( $post->link );
+		$href   = esc_url( $post->link );
 		$title   = esc_html( $post->title->rendered );
 		$excerpt = wp_kses_post( $post->excerpt->rendered );
 		$domain  = wp_parse_url( $post->link, PHP_URL_HOST );
+
+		$image_link = self::render_link( $href, $image );
+		$title_link = self::render_link( $href, $title, ['rel' => 'bookmark', 'class' => 'preview__permalink' ] );
 
 		return "<article class=\"preview is-layout-network\">
 			<div class=\"preview__layout\">
 				<div class=\"preview__start\">
 					<figure class=\"preview__image-container\">
-						<a rel=\"bookmark\" href=\"{$link}\">
-							{$image}
-						</a>
+						{$image_link}
 					</figure>
 				</div>
 				<div class=\"preview__end\">
 					<h3 class=\"preview__title\">
-						<a class=\"preview__permalink\" rel=\"bookmark\" href=\"{$link}\">
-							{$title}
-						</a>
+						{$title_link}
 					</h3>
 					<div class=\"preview__excerpt\">{$excerpt}</div>
 					<p class=\"preview__domain\">{$domain}</p>

--- a/blocks/rest/includes/layout/trending/class-trending.php
+++ b/blocks/rest/includes/layout/trending/class-trending.php
@@ -66,10 +66,10 @@ class Trending extends Layout {
 	 * @param stdClass $post
 	 */
 	public static function render_preview_small( stdClass $post ) : string {
-		$title  = esc_html( $post->title->rendered );
-		$link   = esc_url( $post->link );
-		$anchor = "<a href=\"{$link}\">{$title}</a>";
-		return "<p>{$anchor}</p>";
+		$title = esc_html( $post->title->rendered );
+		$href  = esc_url( $post->link );
+		$link  = self::render_link( $href, $title );
+		return "<p>{$link}</p>";
 	}
 
 	/**
@@ -81,7 +81,7 @@ class Trending extends Layout {
 	 */
 	public static function render_preview( stdClass $post, ?string $image = '' ) : string {
 		$title  = esc_html( $post->title->rendered );
-		$link   = esc_url( $post->link );
+		$href   = esc_url( $post->link );
 		$kicker = self::render_kicker(
 			self::get_category( $post )
 		);
@@ -89,16 +89,17 @@ class Trending extends Layout {
 			self::get_author( $post )
 		);
 
+		$link_one = self::render_link( $href, $image, ['rel' => 'bookmark'] );
+		$link_two = self::render_link( $href, $title, ['rel' =>  'bookmark', 'class' => 'preview__permalink'] );
+
 		return "<article class=\"preview is-layout-trending\">
 			<figure class=\"preview__image-container\">
-				<a rel=\"bookmark\" href=\"{$link}\">
-					{$image}
-				</a>
+				{$link_one}
 			</figure>
 			<div class=\"preview__content\">
 				{$kicker}
 				<h3 class=\"preview__title\">
-					<a class=\"preview__permalink\" rel=\"bookmark\" href=\"{$link}\">{$title}</a>
+					{$link_two}
 				</h3>
 				{$byline}
 			</div>
@@ -158,9 +159,11 @@ class Trending extends Layout {
 			)
 		);
 
+		$link = self::render_link( $href, "<em>{$name}</em>", ['rel' => 'author'] );
+
 		return "<p class=\"preview__byline\">
 			{$image}
-			<a rel=\"author\" href=\"{$href}\"><em>{$name}</em></a>
+			{$link}
 		</p>";
 	}
 
@@ -270,11 +273,10 @@ class Trending extends Layout {
 		if ( null === $category ) {
 			return '';
 		}
-		$link = esc_url( $category->link );
+		$href = esc_url( $category->link );
 		$name = esc_html( $category->name );
-		return "<p class=\"preview__kicker\">
-			<a rel=\"category\" href=\"{$link}\"><strong>{$name}</strong></a>
-		</p>";
+		$link = self::render_link( $href, "<strong>{$name}</strong>", ['rel' => 'category'] );
+		return "<p class=\"preview__kicker\">{$link}</p>";
 	}
 
 }

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.2-beta1
+ * Version:     0.10.2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.1
+ * Version:     0.10.2-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.2-beta1",
+	"version": "0.10.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.2-beta1",
+			"version": "0.10.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.1",
+	"version": "0.10.2-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.1",
+			"version": "0.10.2-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.2-beta1",
+	"version": "0.10.2",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.1",
+	"version": "0.10.2-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #162 
  - I didn't make it optional because it would require a bigger rewrite of our rending to include more options. That could happen in the future but isn't necessary since optional was my idea, not part of the user's feature request.

### What Was Accomplished
- Added a `render_link` function which accepts a URL, the content of the anchor and an array of HTML attributes. It produces an `<a>` while checking if the URL starts with the same characters as the result of `home_url()`. If there's a mismatch the link gets `target="_blank"`
  - I expect that calling `home_url()` is faster than doing a regex each time, but I haven't tested that theory.

### How It Was Tested
- [x] Local plugin development environment
- [x] Remote site environment

### How To Test
- [x] Links to the same domain stay in the same tab
- [x] Links to another domain open in a new tab where available