### PR TITLE
Issue#167/network link max inline size

### DIFF
--- a/blocks/network-link/build/style-index-rtl.css
+++ b/blocks/network-link/build/style-index-rtl.css
@@ -1,1 +1,1 @@
-.wp-block-cata-network-link{display:block;list-style:none}.wp-block-cata-network-link a,.wp-block-cata-network-link svg{display:block}.wp-block-cata-network-link svg{block-size:auto;max-inline-size:100%;min-inline-size:100%;overflow:visible}
+.wp-block-cata-network-link{display:block;list-style:none;max-inline-size:100%}.wp-block-cata-network-link a,.wp-block-cata-network-link svg{display:block}.wp-block-cata-network-link svg{block-size:auto;max-inline-size:100%;min-inline-size:100%;overflow:visible}

--- a/blocks/network-link/build/style-index.css
+++ b/blocks/network-link/build/style-index.css
@@ -1,1 +1,1 @@
-.wp-block-cata-network-link{display:block;list-style:none}.wp-block-cata-network-link a,.wp-block-cata-network-link svg{display:block}.wp-block-cata-network-link svg{block-size:auto;max-inline-size:100%;min-inline-size:100%;overflow:visible}
+.wp-block-cata-network-link{display:block;list-style:none;max-inline-size:100%}.wp-block-cata-network-link a,.wp-block-cata-network-link svg{display:block}.wp-block-cata-network-link svg{block-size:auto;max-inline-size:100%;min-inline-size:100%;overflow:visible}

--- a/blocks/network-link/src/style.scss
+++ b/blocks/network-link/src/style.scss
@@ -6,6 +6,7 @@
 .wp-block-cata-network-link {
 	display: block;
 	list-style: none;
+	max-inline-size: 100%;
 
 	a, svg {
 		display: block;

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.3-beta1
+ * Version:     0.10.3
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.2
+ * Version:     0.10.3-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.3-beta1",
+	"version": "0.10.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.3-beta1",
+			"version": "0.10.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.2",
+	"version": "0.10.3-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.2",
+			"version": "0.10.3-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.3-beta1",
+	"version": "0.10.3",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.2",
+	"version": "0.10.3-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Closes #167 

### What Was Accomplished
- Added a `max-inline-size` to network link blocks

### How It Was Tested
- [x] Locally on parent theme
- [x] Locally on child theme
- [x] Child theme develop

### How To Test
- The network link block shrinks to fit the screen size if the screen is smaller than the width set in the editor