### PR TITLE
Issue#176/rest speed

### DIFF
--- a/blocks/rest/rest.php
+++ b/blocks/rest/rest.php
@@ -115,7 +115,7 @@ function convert_urls_to_posts( array $urls ) : array {
  * @return array $posts
  */
 function convert_url_to_posts( string $url ) : array {
-	$decoded_url = html_entity_decode( $url );
+	$decoded_url = URLs::get_standardized_rest_api_url( $url );
 	return (new Feed( new Feed\Cache( $decoded_url ), $decoded_url ) )->get_posts_allow_side_effects();
 }
 

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.8-beta1
+ * Version:     0.10.8
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -87,6 +87,13 @@ require_once __DIR__ . '/includes/proxy/class-proxy.php';
 new Proxy();
 
 /**
+ * URLs
+ */
+require_once __DIR__ . '/includes/urls/class-urls.php';
+
+new URLs();
+
+/**
  * Table of Contents
  */
 require_once __DIR__ . '/blocks/table-of-contents/table-of-contents.php';

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.7
+ * Version:     0.10.8-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/proxy/class-proxy.php
+++ b/includes/proxy/class-proxy.php
@@ -65,7 +65,11 @@ class Proxy {
 	 * @return WP_REST_Response|WP_Error either an error or a json decoded api response body
 	 */
 	public static function handle_request( WP_REST_Request $request ) : WP_REST_Response|WP_Error {
-		$url   = $request->get_param( 'url' );
+
+		$url = URLs::get_standardized_rest_api_url(
+			$request->get_param( 'url' )
+		);
+
 		$fetch = new Fetch( $url );
 		$cache = new Cache( $url );
 

--- a/includes/urls/class-urls.php
+++ b/includes/urls/class-urls.php
@@ -3,7 +3,7 @@
  * URLs
  *
  * @package Cata\Blocks
- * @since
+ * @since 0.10.8
  */
 
 namespace Cata\Blocks;

--- a/includes/urls/class-urls.php
+++ b/includes/urls/class-urls.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * URLs
+ *
+ * @package Cata\Blocks
+ * @since
+ */
+
+namespace Cata\Blocks;
+
+/**
+ * URLs
+ */
+class URLs {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'cata_blocks_get_standardized_rest_api_url', [ __CLASS__, 'conditionally_add_embed_to_url' ] );
+		add_filter( 'cata_blocks_get_standardized_rest_api_url', 'html_entity_decode' );
+		add_filter( 'cata_blocks_get_standardized_rest_api_url', 'urldecode' );
+	}
+
+	/**
+	 * Conditionally Add Embed to URL
+	 * 
+	 * We want to add _embed to REST API request in a consistent manner,
+	 * unless its changed on purpose in the editor.
+	 *
+	 * @param string $url A REST API URL
+	 * @return string URL where _embed may have been added to the query string.
+	 */
+	public static function conditionally_add_embed_to_url( string $url ): string {
+
+		$parsed_url = wp_parse_url( $url );
+
+		// return original url, its weird.
+		if ( ! is_array( $parsed_url ) ) {
+			return $url;
+		}
+
+		$default = add_query_arg(
+			[
+				'_embed' => 'wp:featuredmedia,wp:term'
+			],
+			$url
+		);
+
+		// return original url with _embed added to query.
+		if ( '' === ( $parsed_url['query'] ?? '' ) ) {
+			return $default;
+		}
+
+		$qs = array();
+
+		// parse query into $qs variable.
+		wp_parse_str( $parsed_url['query'], $qs );
+
+		// if $qs is still empty we're done.
+		if ( empty( $qs ) ) {
+			return $default;
+		}
+
+		// if _embed is already present we're done.
+		if ( array_key_exists( '_embed', $qs ) ) {
+			return $url;
+		}
+
+		// return original url with _embed added to query.
+		return $default;
+	}
+
+	/**
+	 * Get Standardized REST API URL
+	 * 
+	 * @param string $url Any REST API URL
+	 * @return string $url Decoded URL with _embed parameter 
+	 */
+	public static function get_standardized_rest_api_url( string $url ): string {
+		return apply_filters( 'cata_blocks_get_standardized_rest_api_url', $url );
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.8-beta1",
+	"version": "0.10.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.8-beta1",
+			"version": "0.10.8",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.7",
+	"version": "0.10.8-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.7",
+			"version": "0.10.8-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.7",
+	"version": "0.10.8-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.8-beta1",
+	"version": "0.10.8",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #176 

### What Was Accomplished
- Added `get_standardized_rest_api_url` function that applies html_entity decoding as well as url decoding and conditionally adds the agreed upon `_embed` parameter to the query string.

### How It Was Tested
- [x] Local dev site
- [x] Remote dev site

### How To Test
- [x] The block works in the editor and rendered content without throwing errors.
- [x] Data that should come through as embeds ( featured media and coauthors ) are visible in the editor and rendered content.
- [x] URLs are saved consistently in block attributes