### PR TITLE
Issue#141/flex grow post blocks

### DIFF
--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.11
+ * Version:     0.10.12-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.12-beta1
+ * Version:     0.10.12
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -24,6 +24,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Filters
+ * 
+ * Change block output with the render_block filter
+ */
+require_once __DIR__ . '/includes/filters/class-filters.php';
+
+new Filters();
+
+/**
  * Middleware
  * 
  * REST block depends on this file

--- a/includes/filters/class-filters.php
+++ b/includes/filters/class-filters.php
@@ -3,7 +3,7 @@
  * Filters
  *
  * @package Cata\Blocks
- * @since 0.8.22
+ * @since 0.10.12
  */
 
 namespace Cata\Blocks;

--- a/includes/filters/class-filters.php
+++ b/includes/filters/class-filters.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Filters
+ *
+ * @package Cata\Blocks
+ * @since 0.8.22
+ */
+
+namespace Cata\Blocks;
+
+use WP_HTML_Tag_Processor;
+
+/**
+ * Filters
+ */
+class Filters {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'render_block', array( __CLASS__, 'add_flex_grow_to_featured_image_block' ), 10, 2 );
+	}
+
+	/**
+	 * Add Flex Grow to Featured Image Block
+	 * 
+	 * @param string $block_content
+	 * @param array $block
+	 * 
+	 * @return string
+	 */
+	public static function add_flex_grow_to_featured_image_block( string $block_content, array $block ) {
+		if ( 'core/post-featured-image' !== $block['blockName'] ) {
+			return $block_content;
+		}
+
+		$flex_grow = $block['attrs']['cataBlocksFlexGrow'] ?? 0;
+
+		if ( 0 === (int)$flex_grow ) {
+			return $block_content;
+		}
+
+		$block_content = new WP_HTML_Tag_Processor( $block_content );
+	
+		if ( ! $block_content->next_tag( array( 'tag_name' => 'figure' ) ) ) {
+			return $block_content;
+		}
+
+		$style = $block_content->get_attribute( 'style' );
+
+		if ( str_contains( $style ?? '', 'flex-grow' ) ) {
+			return $block_content;
+		}
+
+		$block_content->set_attribute( 'style', $style . 'flex-grow:' . $flex_grow . ';');
+		$block_content->get_updated_html();
+
+		return $block_content;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.12-beta1",
+	"version": "0.10.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.12-beta1",
+			"version": "0.10.12",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.11",
+	"version": "0.10.12-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.11",
+			"version": "0.10.12-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.12-beta1",
+	"version": "0.10.12",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.11",
+	"version": "0.10.12-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
Closes #141 

### What Was Accomplished
- Added a filter for post featured image blocks that adds our custom `flex-grow` attribute to the inline `style` tag

### How It Was Tested
- [x] Locally on parent theme
- [x] Locally on child theme
- [x] Child theme develop

### How To Test
- [x] Add a featured image block to a row block. Then set a fixed width and flex grow in the featured image block styles.
- [x] The flex grow value should be reflected in the editor and the frontend.
- [x] Other inline styles such as margin still work properly on the featured image block.

### Open Questions
This is the only `post-` block that I felt needed to have flex grow work. I think like it makes sense to keep wrapping text elements such as excerpt and title blocks in a group if we need to set flex grow. We could remove the flex grow field in the editor for these other blocks, but we can make a new issue for that if it becomes confusing in the future

