### PR TITLE
Issue#186/blank excerpt

### DIFF
--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.13-beta1
+ * Version:     0.10.13
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.12
+ * Version:     0.10.13-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -19,6 +19,8 @@
 
 namespace Cata\Blocks;
 
+use WP_Block;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -183,6 +185,14 @@ require_once __DIR__ . '/formats/overhang/overhang.php';
  * Substack Social Link Variation
  */
 require_once __DIR__ . '/variations/social-link/substack/substack.php';
+
+/**
+ * Core Block Filters
+ */
+
+require_once __DIR__ . '/core-block-filters/post-excerpt/class-post-excerpt.php';
+
+new Core_Block_Filters\Post_Excerpt();
 
 /**
  * Block Editor 

--- a/core-block-filters/post-excerpt/class-post-excerpt.php
+++ b/core-block-filters/post-excerpt/class-post-excerpt.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Post Excerpt
+ * 
+ * @package Cata_Blocks\Core_Block_Filters
+ */
+
+namespace Cata\Blocks\Core_Block_Filters;
+
+use WP_Block;
+
+/**
+ * Post Excerpt
+ */
+class Post_Excerpt {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'render_block_core/post-excerpt',  [ __CLASS__, 'hide_empty_excerpt_on_single_post_template' ], accepted_args: 3 );
+	}
+
+	/**
+	 * Hide Empty Post Excerpt on Single Post Template
+	 * 
+	 * @param string $block_content
+	 * @param array $block
+	 * @param WP_Block $instance
+	 * @return string
+	 */
+	public static function hide_empty_excerpt_on_single_post_template( string $block_content, array $block, WP_Block $instance ): string {
+
+		if ( ! self::instance_has_post_context( $instance ) ) {
+			return $block_content;
+		}
+
+		if ( ! self::post_context_matches_request( $instance->context ) ) {
+			return $block_content;
+		}
+
+		$post = get_post( $instance->context['postId'] );
+
+		if ( '' === trim( $post->post_excerpt ) ) {
+			return '';
+		}
+
+		return $block_content;
+
+	}
+
+	/**
+	 * Instance Has Post Content
+	 *
+	 * @param WP_Block $instance
+	 * @return bool
+	 */
+	private static function instance_has_post_context( WP_Block $instance ): bool {
+		$context = $instance->context ?? [];
+
+		error_log( print_r( $context, true ) );
+
+		return array_key_exists( 'postId', $context ) && array_key_exists( 'postType', $context );
+	}
+
+	/**
+	 * Post Context Matches Request
+	 *
+	 * @param array $context
+	 * @return bool
+	 */
+	private static function post_context_matches_request( array $context ): bool {
+
+		if ( ! is_singular( $context['postType'] ) ) {
+			return false;
+		}
+	
+		if ( ! is_a( get_queried_object(), 'WP_Post' ) ) {
+			return false;
+		}
+	
+		if ( get_queried_object_id() !== $context['postId'] ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/core-block-filters/post-excerpt/class-post-excerpt.php
+++ b/core-block-filters/post-excerpt/class-post-excerpt.php
@@ -29,7 +29,6 @@ class Post_Excerpt {
 	 * @return string
 	 */
 	public static function hide_empty_excerpt_on_single_post_template( string $block_content, array $block, WP_Block $instance ): string {
-
 		if ( ! self::instance_has_post_context( $instance ) ) {
 			return $block_content;
 		}
@@ -45,7 +44,6 @@ class Post_Excerpt {
 		}
 
 		return $block_content;
-
 	}
 
 	/**
@@ -57,8 +55,6 @@ class Post_Excerpt {
 	private static function instance_has_post_context( WP_Block $instance ): bool {
 		$context = $instance->context ?? [];
 
-		error_log( print_r( $context, true ) );
-
 		return array_key_exists( 'postId', $context ) && array_key_exists( 'postType', $context );
 	}
 
@@ -69,7 +65,6 @@ class Post_Excerpt {
 	 * @return bool
 	 */
 	private static function post_context_matches_request( array $context ): bool {
-
 		if ( ! is_singular( $context['postType'] ) ) {
 			return false;
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.13-beta1",
+	"version": "0.10.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.13-beta1",
+			"version": "0.10.13",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.12",
+	"version": "0.10.13-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.12",
+			"version": "0.10.13-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.12",
+	"version": "0.10.13-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.13-beta1",
+	"version": "0.10.13",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues

- Resolves #186 

### What Was Accomplished
- Added filter on `render_block_core/post-excerpt` to make it return an empty string if ( by our best estimate ) we are looking at the single post template for this particlar post and its excerpt is blank.

### How To Test
- [x] On a single post template, if you output the core/post-excerpt block and the excerpt is empty, nothing is shown.
- [x] If there is a custom excerpt, it is shown.
- [x] Elsewhere on the site, like in a query loop, the excerpt is shown if the post-excerpt block is included.

This is available to test on a remote development site