### PR TITLE
Make all arguments after $posts in rest block render functions optional

### DIFF
--- a/blocks/rest/includes/layout/compact/class-compact.php
+++ b/blocks/rest/includes/layout/compact/class-compact.php
@@ -23,7 +23,7 @@ class Compact extends Layout {
 	 * @param array $posts
 	 * @return string
 	 */
-	public static function render( string $content, array $posts,  bool $display_zodiac_links, string $aspect_ratio ) : string {
+	public static function render( string $content, array $posts, ?bool $display_zodiac_links = false, ?string $aspect_ratio = '' ): string {
 	
 		if ( empty( $posts ) ) {
 			return $content;

--- a/blocks/rest/includes/layout/daily-horoscope/class-daily-horoscope.php
+++ b/blocks/rest/includes/layout/daily-horoscope/class-daily-horoscope.php
@@ -22,7 +22,7 @@ class Daily_Horoscope extends Layout {
 	 * @param array $posts
 	 * @return string
 	 */
-	public static function render( string $content, array $posts, bool $display_zodiac_links ): string {
+	public static function render( string $content, array $posts, ?bool $display_zodiac_links = false ): string {
 		if ( empty( $posts ) ) {
 			return $content;
 		}

--- a/blocks/rest/includes/layout/network/class-network.php
+++ b/blocks/rest/includes/layout/network/class-network.php
@@ -22,7 +22,7 @@ class Network extends Layout {
 	 * @param array $posts
 	 * @return string
 	 */
-	public static function render( string $content, array $posts, bool $display_zodiac_links, string $aspect_ratio ) : string {
+	public static function render( string $content, array $posts, ?bool $display_zodiac_links = false, ?string $aspect_ratio = '' ): string {
 	
 		if ( empty( $posts ) ) {
 			return $content;

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.15
+ * Version:     0.10.16-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.15",
+	"version": "0.10.16-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.15",
+			"version": "0.10.16-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.15",
+	"version": "0.10.16-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- #190 
- After shipping #191 I encountered "too few arguments" errors in environments where the aspect ratio had never been set for the compact layout.

### What Was Accomplished
- Updated all `render` functions in the REST API block layout classes so that the arguments after `$posts` are optional and have default values that make them have no effect.

### How It Was Tested
- [ ] Local
- [ ] Remote

### How To Test
- [ ] Existing blocks using compact layout continue to work
- [ ] No `too few arguments` errors
- [ ] Blocks update over time ( errors result in old content from when the block was added to the post being displayed )