### PR TITLE
Issue#202/view script module

### DIFF
--- a/blocks/table-of-contents/build/block.json
+++ b/blocks/table-of-contents/build/block.json
@@ -67,7 +67,7 @@
       "content": "Table Of Contents"
     }
   },
-  "script": "file:./script.js",
+  "viewScriptModule": "file:./script.js",
   "editorScript": "file:./index.js",
   "editorStyle": "file:./index.css",
   "style": "file:./style-index.css"

--- a/blocks/table-of-contents/src/block.json
+++ b/blocks/table-of-contents/src/block.json
@@ -63,7 +63,7 @@
 			"content": "Table Of Contents"
 		}
 	},
-	"script": "file:./script.js",
+	"viewScriptModule": "file:./script.js",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"

--- a/blocks/table-of-contents/table-of-contents.php
+++ b/blocks/table-of-contents/table-of-contents.php
@@ -22,54 +22,6 @@ function register_toc_block() : void {
 add_action( 'init', __NAMESPACE__ . '\\register_toc_block' );
 
 /**
- * Add defer attribute to Table of Contents script tag
- * 
- * The script enqueued by the block editor runs before the DOM is fully built; this deferment ensures the script can parse the DOM after it's built.
- *
- * @param [type] $tag - The <script> tag of the enqueued script being filtered.
- * @param [type] $handle - The registered handle of the enqueued script being filtered.
- * @param [type] $src - The src URL of the enqueued script being filtered.
- * @return string - Returns the script tag either unmodified or, if it is the Table of Contents script it adds the defer tag.
- */
-function add_defer_to_toc_script( $tag, $handle, $src ) {
-	if ( 'cata-toc-script' !== $handle ) {
-		return $tag;
-	}
-	return '<script defer="defer" type="text/javascript" src="' . $src . '"></script>';
-}
-
-add_filter( 'script_loader_tag', __NAMESPACE__ . '\\add_defer_to_toc_script', 10, 3 );
-
-/**
- * Remove Table of Contents from Block Editor
- * 
- * Prevents Table of Contents script from running in the block editor without affecting the front end execution.
- *
- * @return void
- */
-function remove_editor_toc_script() {
-	wp_dequeue_script( 'cata-toc-script' );
-	wp_deregister_script( 'cata-toc-script' );
-}
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\remove_editor_toc_script', 10, 0 );
-
-/**
- * Conditionally Remove Script
- * Remove block script if the post or page does not contain it.
- */
-function conditionally_remove_script() : void {
-	// singular includes a page used as front-page, single does not.
-	if ( ! is_singular() ) {
-		return;
-	}
-	if ( has_block( 'cata/toc' ) ) {
-		return;
-	}
-	wp_dequeue_script( 'cata-toc-script' );
-}
-add_action( 'wp_enqueue_scripts', __NAMESPACE__. '\\conditionally_remove_script' );
-
-/**
  * Enable Generate Anchors
  *
  * @link https://github.com/WordPress/gutenberg/pull/38780#issuecomment-1122412396

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.21
+ * Version:     0.10.22-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.21",
+	"version": "0.10.22-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.21",
+			"version": "0.10.22-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.21",
+	"version": "0.10.22-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issue
- Resolves #202 

### What Was Accomplished
- Changed the `script` property in the table-of-contents' block.json to `viewScriptModule` so it is enqueued only when the block is used and is defered by being `type=module`

### How It Was Tested
- [x] Local
- [x] Remote dev site

### How To Test
- [ ] Table of Contents still works in normal context
- [ ] It now also works when used in a synched pattern
