### PR TITLE
Issue#204/network links update

### DIFF
--- a/blocks/network-link/build/block.json
+++ b/blocks/network-link/build/block.json
@@ -6,7 +6,7 @@
   "title": "Network Link",
   "category": "widgets",
   "parent": [
-    "core/network-links"
+    "cata/network-links"
   ],
   "description": "Display a logo linking to another site in the Thought Catalog network.",
   "supports": {

--- a/blocks/network-link/src/block.json
+++ b/blocks/network-link/src/block.json
@@ -5,7 +5,7 @@
 	"version": "0.1.0",
 	"title": "Network Link",
 	"category": "widgets",
-	"parent": [ "core/network-links" ],
+	"parent": [ "cata/network-links" ],
 	"description": "Display a logo linking to another site in the Thought Catalog network.",
 	"supports": {
 		"html": false,

--- a/blocks/network-link/src/variations.js
+++ b/blocks/network-link/src/variations.js
@@ -65,7 +65,9 @@ const variations = [
  *  Block by providing its attributes.
  */
 variations.forEach( ( variation ) => {
-	if ( variation.isActive ) return;
+	if ( variation.isActive ) {
+		return;
+	}
 	variation.isActive = ( blockAttributes, variationAttributes ) =>
 		blockAttributes.service === variationAttributes.service;
 } );

--- a/blocks/network-links/build/block.json
+++ b/blocks/network-links/build/block.json
@@ -71,5 +71,6 @@
     ]
   },
   "editorScript": "file:./index.js",
+  "editorStyle": "file:./index.css",
   "style": "file:./style-index.css"
 }

--- a/blocks/network-links/build/index-rtl.css
+++ b/blocks/network-links/build/index-rtl.css
@@ -1,0 +1,1 @@
+.wp-block-cata-network-links__prompt{list-style:none}

--- a/blocks/network-links/build/index.asset.php
+++ b/blocks/network-links/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-blocks', 'wp-i18n'), 'version' => '8ecb1050bc0d189017db');
+<?php return array('dependencies' => array('react-jsx-runtime', 'wp-block-editor', 'wp-blocks', 'wp-i18n'), 'version' => '7ee21e06237ea654aa4d');

--- a/blocks/network-links/build/index.css
+++ b/blocks/network-links/build/index.css
@@ -1,0 +1,1 @@
+.wp-block-cata-network-links__prompt{list-style:none}

--- a/blocks/network-links/src/block.json
+++ b/blocks/network-links/src/block.json
@@ -55,5 +55,6 @@
 		]
 	},
 	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
 	"style": "file:./style-index.css"
 }

--- a/blocks/network-links/src/edit.js
+++ b/blocks/network-links/src/edit.js
@@ -8,6 +8,14 @@ import { useInnerBlocksProps, useBlockProps, } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Lets webpack process CSS, SASS or SCSS files referenced in JavaScript files.
+ * Those files can contain any CSS code that gets applied to the editor.
+ *
+ * @see https://www.npmjs.com/package/@wordpress/scripts#using-css
+ */
+import './editor.scss';
+
+/**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
 *

--- a/blocks/network-links/src/editor.scss
+++ b/blocks/network-links/src/editor.scss
@@ -1,0 +1,7 @@
+/**
+ * The following styles get applied inside the editor only.
+ */
+
+.wp-block-cata-network-links__prompt {
+	list-style: none;
+}

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.23-beta1
+ * Version:     0.10.23
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.10.22
+ * Version:     0.10.23-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.23-beta1",
+	"version": "0.10.23",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.23-beta1",
+			"version": "0.10.23",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.22",
+	"version": "0.10.23-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.10.22",
+			"version": "0.10.23-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.22",
+	"version": "0.10.23-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.10.23-beta1",
+	"version": "0.10.23",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related issues
- Closes #204 

### What Was Accomplished
- Removed list style from the placeholder text in the editor for the network links block
- Replaced single line if statement with statement block based on a recent update to the social links block
- Fixed namespace on the parent block setting for the network link block (this is what was causing the actual problem with 6.8, and I don't know how it was working before)

### How It Was Tested
- [x] Locally on parent theme
- [x] Locally on child theme
- [x] Child theme develop

### How To Test
- [x] Existing network link blocks are still working
- [x] In the editor when adding a new network links block, there is no bullet next to the "click plus to add" message
- [x] Network link blocks can be added to the network links block