### PR TITLE
Updated string interpolation in newsletter block

### DIFF
--- a/blocks/newsletter/includes/class-renderer.php
+++ b/blocks/newsletter/includes/class-renderer.php
@@ -39,9 +39,9 @@ class Renderer {
 		$legal_text   = $this->get_legal_text();
 		$wrapper_attr = get_block_wrapper_attributes();
 
-		return "<div ${wrapper_attr}>
-			${form}
-			${legal_text}
+		return "<div {$wrapper_attr}>
+			{$form}
+			{$legal_text}
 		</div>";
 	}
 
@@ -63,7 +63,7 @@ class Renderer {
 			str_replace( '%%Privacy Policy%%', $privacy_policy, $legal_text )
 		);
 
-		return "<p><small>${legal_text}</small></p>";
+		return "<p><small>{$legal_text}</small></p>";
 	}
 
 	/**
@@ -77,7 +77,7 @@ class Renderer {
 		$action      = esc_url( $this->get_form_action( $user_id, $audience_id ) );
 		$success     = esc_attr( $this->attributes['successMessage'] );
 		
-		return "<form method=\"post\" action=\"${action}\" data-mailchimp-success-message=\"${success}\" name=\"mc-embedded-subscribe-form\" target=\"_blank\" data-mailchimp validate>
+		return "<form method=\"post\" action=\"{$action}\" data-mailchimp-success-message=\"{$success}\" name=\"mc-embedded-subscribe-form\" target=\"_blank\" data-mailchimp validate>
 			<div role=\"alert\"></div>
 			<fieldset>
 				<label class=\"screen-reader-text\" for=\"mce-EMAIL\">Enter your email</label>
@@ -86,7 +86,7 @@ class Renderer {
 			</fieldset>
 			<div class=\"position: relative; overflow:hidden\">
 				<div style=\"position: absolute; left: -5000px;\" aria-hidden=\"true\">
-					<input type=\"text\" name=\"b_${user_id}_${audience_id}\" tabindex=\"-1\" value=\"\">
+					<input type=\"text\" name=\"b_{$user_id}_{$audience_id}\" tabindex=\"-1\" value=\"\">
 				</div>
 			</div>
 		</form>";

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.11.9-beta1
+ * Version:     0.11.9
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.11.8
+ * Version:     0.11.9-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.11.9-beta1",
+	"version": "0.11.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.11.9-beta1",
+			"version": "0.11.9",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.11.8",
+	"version": "0.11.9-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.11.8",
+			"version": "0.11.9-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.11.9-beta1",
+	"version": "0.11.9",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.11.8",
+	"version": "0.11.9-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related Issues
- Resolves #221 

### What Was Accomplished
- Updated string interpolation in the newsletter block's render function to use `{$}` instead of `${}`

### How It Was Tested
- [x] Local dev env
- [x] Remote dev env

### How To Test

Available on the Creepy Catalog develop environment where we have the newsletter block on the homepage

- [x] Newsletter block still renders correctly