### PR TITLE
Issue#230/allow color scheme property

### DIFF
--- a/block-editor/color-scheme/color-scheme.php
+++ b/block-editor/color-scheme/color-scheme.php
@@ -26,3 +26,12 @@ function cata_color_scheme_enqueue_scripts(): void {
 	wp_add_inline_style( 'wp-block-editor', 'body.has-active-dark-mode-element .block-editor-panel-color-gradient-settings__dropdown-content, body.has-active-dark-mode-element .block-editor-tools-panel-color-gradient-settings__dropdown { color-scheme: dark only; }');
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\cata_color_scheme_enqueue_scripts' );
+
+/**
+ * Allow Color Scheme CSS Property
+ */
+function cata_allow_color_scheme_css_property( array $props ): array {
+	$props[] = 'color-scheme';
+	return $props;
+}
+add_filter( 'safe_style_css', __NAMESPACE__ . '\\cata_allow_color_scheme_css_property' );

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.12.1-beta1
+ * Version:     0.12.1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.12.0
+ * Version:     0.12.1-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.12.0",
+	"version": "0.12.1-beta1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.12.0",
+			"version": "0.12.1-beta1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.12.1-beta1",
+	"version": "0.12.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.12.1-beta1",
+			"version": "0.12.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.12.0",
+	"version": "0.12.1-beta1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.12.1-beta1",
+	"version": "0.12.1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
### Related issues
- Closes #231 

### What was accomplished
- Added a filter on `safe_style_css` to add `color-scheme` to allowed list of CSS properties

### How it was tested
- [x] Local

### How to test
- [x] Replicate the bug before upgrading Cata Blocks by logging in as an editor and saving a page that have blocks that use the color scheme feature. Reload the block editor after saving, and the blocks that use color scheme should have the "invalid content" error.
- [x] After confirming the error exists, recover all blocks and update Cata Blocks to `0.12.1-beta1`
- [x] Make an update on the page again as an editor. After reloading, there should be no "invalid content" errors