### PR TITLE
0.13.1 — art-direction: auto preview matches render

### DIFF
--- a/blocks/art-direction/includes/selection.php
+++ b/blocks/art-direction/includes/selection.php
@@ -263,6 +263,6 @@ function get_art_direction_data( WP_Post $post ): array {
 		'images'   => array_map( __NAMESPACE__ . '\\add_image_src', $good_images ),
 		'diptych'  => null !== $diptych ? array( add_image_src( $diptych ) ) : array(),
 		'collage'  => array_map( __NAMESPACE__ . '\\add_image_src', $collage ),
-		'auto'     => ! empty( $collage ) ? 'collage' : 'single',
+		'auto'     => resolve_layout( 'auto', $post )['layout'],
 	);
 }

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.0
+ * Version:     0.13.1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.0",
+			"version": "0.13.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
Follow-up to #261. The editor-preview `auto` value (REST field) hardcoded collage-or-single, so a post the render template auto-diptychs previewed as **single**, breaking preview/render parity. Now delegates to `resolve_layout` — one source of truth. Verified against live prod posts.