### PR TITLE
0.13.3 — image-lightbox: bust asset cache for the tap-to-navigate styles

### DIFF
--- a/blocks/image-lightbox/build/block.json
+++ b/blocks/image-lightbox/build/block.json
@@ -2,7 +2,7 @@
   "$schema": "https://schemas.wp.org/trunk/block.json",
   "apiVersion": 3,
   "name": "cata/image-lightbox",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "title": "Image Lightbox",
   "category": "design",
   "description": "Opens every image in the post content inside a modal slider lightbox.",

--- a/blocks/image-lightbox/src/block.json
+++ b/blocks/image-lightbox/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "cata/image-lightbox",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"title": "Image Lightbox",
 	"category": "design",
 	"description": "Opens every image in the post content inside a modal slider lightbox.",

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.2
+ * Version:     0.13.3
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.2",
+	"version": "0.13.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.2",
+			"version": "0.13.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.2",
+	"version": "0.13.3",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
Follow-up to #263. The lightbox's style/script assets are enqueued with the block.json `version` (0.1.0) as their `?ver`, which never changed — so returning visitors' browsers kept the cached CSS and never got the new tap-to-navigate zone styles (verified live: the deployed `style-index.css` has the rules, but the page requests `?ver=0.1.0` which is browser-cached stale). Bumps the block version to **0.1.1** so the `?ver` busts. Also flags a latent issue for future block changes.