### PR TITLE
0.13.4 — image-lightbox: auto-version the stylesheet by its content hash

### DIFF
--- a/blocks/image-lightbox/image-lightbox.php
+++ b/blocks/image-lightbox/image-lightbox.php
@@ -23,6 +23,34 @@ function register_image_lightbox_block() {
 add_action( 'init', __NAMESPACE__ . '\\register_image_lightbox_block' );
 
 /**
+ * Version the block's stylesheet by its own content hash.
+ *
+ * WordPress versions a block's `style` with the static block.json `version`,
+ * so CSS changes never bust returning visitors' caches. The generated
+ * `*.asset.php` version can't stand in for it either: wp-scripts extracts the
+ * CSS to its own file, so that hash only tracks the JS and a CSS-only change
+ * leaves it unchanged. Hash the built stylesheet instead, so its `?ver`
+ * changes exactly when the CSS does — automatically, on every build.
+ *
+ * @param array $metadata Parsed block.json metadata.
+ * @return array Metadata, with a content-derived version for this block.
+ */
+function version_image_lightbox_style( array $metadata ): array {
+	if ( 'cata/image-lightbox' !== ( $metadata['name'] ?? '' ) ) {
+		return $metadata;
+	}
+
+	$stylesheet = __DIR__ . '/build/style-index.css';
+
+	if ( is_readable( $stylesheet ) ) {
+		$metadata['version'] = substr( md5_file( $stylesheet ), 0, 20 );
+	}
+
+	return $metadata;
+}
+add_filter( 'block_type_metadata', __NAMESPACE__ . '\\version_image_lightbox_style' );
+
+/**
  * Register Image Lightbox Meta
  *
  * Lightbox-only images: attachment ids stored on the post, appended to the

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.3
+ * Version:     0.13.4
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.3",
+			"version": "0.13.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.3",
+	"version": "0.13.4",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
Per @douglas-johnson's suggestion — replace the manual block.json version bump (0.13.3) with an automatic cache-bust derived from the build.

A `block_type_metadata` filter sets the block's version to a hash of the built `style-index.css`, so the style `?ver` busts exactly when the CSS changes, every build — no manual bump.

**Why not the `*.asset.php` version directly (Doug's literal suggestion):** verified that wp-scripts extracts the CSS to its own file, so the asset-file `version` only tracks the JS — a CSS-only change (like the tap-to-navigate styles) leaves it unchanged. Hashing the built stylesheet is the CSS equivalent of what the JS already gets. The scripts keep their own `*.asset.php` versions.

Scoped to image-lightbox for now; trivially generalizable to every block if we want (same filter, keyed off `$metadata['file']`).