### PR TITLE
image-lightbox: gate gallery on 6+ in-content photos, drop featured image (0.13.10)

### DIFF
--- a/blocks/image-lightbox/image-lightbox.php
+++ b/blocks/image-lightbox/image-lightbox.php
@@ -181,41 +181,39 @@ function cata_image_lightbox_get_post_images( WP_Post $post ): array {
 	static $cache = array();
 
 	if ( ! array_key_exists( $post->ID, $cache ) ) {
-		$images   = cata_image_lightbox_get_images( parse_blocks( $post->post_content ) );
-		$featured = cata_image_lightbox_featured_image( $post );
-
-		// Lead with the featured image.
-		if ( null !== $featured ) {
-			array_unshift( $images, $featured );
-		}
+		$images = cata_image_lightbox_get_images( parse_blocks( $post->post_content ) );
 
 		/**
-		 * Filter the collected lightbox images so themes can add slides.
+		 * Minimum in-content photos before a post becomes a lightbox gallery.
+		 * Image-light posts (fewer than this) stay ungalleried unless an editor
+		 * curates lightbox images to force one on. The featured image is never a
+		 * slide, so only in-content photos count toward this minimum.
 		 *
-		 * Each entry must have src, alt, id, and caption keys; id may be 0 for
-		 * images that are not attachments.
-		 *
-		 * @param array<int, array{src: string, alt: string, id: int, caption: string}> $images
-		 * @param WP_Post                                                               $post
+		 * @param int $minimum Minimum in-content image count. Default 6.
 		 */
-		$cache[ $post->ID ] = apply_filters( 'cata_blocks_image_lightbox_images', $images, $post );
+		$minimum = (int) apply_filters( 'cata_blocks_image_lightbox_minimum_images', 6 );
+
+		// Curated lightbox images (the cata_lightbox_image_ids meta) force the
+		// gallery on no matter how few in-content photos the post has.
+		$forced = array() !== (array) get_post_meta( $post->ID, 'cata_lightbox_image_ids', true );
+
+		if ( count( $images ) < $minimum && ! $forced ) {
+			$cache[ $post->ID ] = array();
+		} else {
+			/**
+			 * Filter the collected lightbox images so themes can add slides.
+			 *
+			 * Each entry must have src, alt, id, and caption keys; id may be 0 for
+			 * images that are not attachments.
+			 *
+			 * @param array<int, array{src: string, alt: string, id: int, caption: string}> $images
+			 * @param WP_Post                                                               $post
+			 */
+			$cache[ $post->ID ] = apply_filters( 'cata_blocks_image_lightbox_images', $images, $post );
+		}
 	}
 
 	return $cache[ $post->ID ];
-}
-
-/**
- * Featured image
- *
- * Build the featured image's slide entry so the most prominent image on the
- * page can lead the gallery.
- *
- * @param WP_Post $post
- *
- * @return array{src: string, alt: string, id: int, caption: string}|null
- */
-function cata_image_lightbox_featured_image( WP_Post $post ): ?array {
-	return cata_image_lightbox_attachment_image( (int) get_post_thumbnail_id( $post ) );
 }
 
 /**
@@ -740,64 +738,6 @@ function cata_image_lightbox_wrap_trigger( string $html, int $index, int $total 
 
 	return substr_replace( $html, $replacement, $offset, strlen( $img ) );
 }
-
-/**
- * Add badge to featured image
- *
- * Filter the queried post's thumbnail markup so the featured image opens the
- * lightbox like the content images do. Post thumbnails don't carry the
- * wp-image-{id} class, so the slide is matched here by attachment id and the
- * wrapper ships the index for the view script.
- *
- * @param string $html
- * @param int    $post_id
- * @param int    $post_thumbnail_id
- *
- * @return string
- */
-function cata_image_lightbox_add_featured_badge( string $html, int $post_id, int $post_thumbnail_id ): string {
-
-	if ( ! apply_filters( 'cata_blocks_support_image_lightbox_block', true ) ) {
-		return $html;
-	}
-
-	if ( '' === $html || is_admin() || ! is_singular() ) {
-		return $html;
-	}
-
-	$post = get_queried_object();
-
-	// Leave thumbnails of other posts (related-post loops, etc.) alone.
-	if ( ! $post instanceof WP_Post || $post->ID !== $post_id ) {
-		return $html;
-	}
-
-	// Leave thumbnails the theme made into links.
-	if ( preg_match( '#<a\b#i', $html ) ) {
-		return $html;
-	}
-
-	$images = cata_image_lightbox_get_post_images( $post );
-
-	if ( empty( $images ) ) {
-		return $html;
-	}
-
-	$index = cata_image_lightbox_find_index(
-		array(
-			'id'  => (int) $post_thumbnail_id,
-			'src' => '',
-		),
-		$images
-	);
-
-	if ( null === $index ) {
-		return $html;
-	}
-
-	return cata_image_lightbox_wrap_trigger( $html, $index, count( $images ) );
-}
-add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\\cata_image_lightbox_add_featured_badge', 10, 3 );
 
 /**
  * Enqueue badge styles

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.9
+ * Version:     0.13.10
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.8",
+	"version": "0.13.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.8",
+			"version": "0.13.10",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.9",
+	"version": "0.13.10",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
## What
Two related product changes to when/what the lightbox gallery shows:

1. **Minimum photo threshold.** A post only gets a lightbox gallery if it has **6 or more in-content photos**, *unless* an editor has curated lightbox images via the `cata_lightbox_image_ids` meta — which forces the gallery on regardless of count. Threshold is filterable via `cata_blocks_image_lightbox_minimum_images` (default 6).
2. **Featured image is never a slide.** Stop prepending the post's featured image to the gallery. The gallery is the in-content photos; the featured image is the hero, not part of it.

## Why
Image-light posts (a hero + a couple of body images) were turning into full galleries, which isn't the intended experience. The gallery should be reserved for genuinely image-rich posts.

## How
- `cata_image_lightbox_get_post_images()` now counts in-content photos and returns an empty set (no gallery) below the minimum unless forced by curated meta.
- Removed the featured-image collector (`cata_image_lightbox_featured_image`) and the `post_thumbnail_html` trigger filter (`cata_image_lightbox_add_featured_badge`). Because slide indices are resolved by lookup (`find_index` against the actual slide array), the in-content triggers self-correct — no index bookkeeping needed.

## Impact
This removes the gallery (and its in-gallery ad slot) from every post with 5 or fewer in-content photos. Intended, but broad — worth a look before merge.

PHP linted clean. No build needed (image-lightbox.php is loaded directly, not compiled).

cc @jessica-townsend — this touches your block; flagging since it changes gallery display behavior and the ad-slot surface you're coordinating with Raptive.