### PR TITLE
0.13.11 — art-direction: dedupe images by file size

### DIFF
--- a/blocks/art-direction/includes/selection.php
+++ b/blocks/art-direction/includes/selection.php
@@ -33,11 +33,23 @@ const LAYOUTS = array( 'auto', 'single', 'diptych', 'collage' );
  * @return array[] List of arrays: id, width, height, alt, orientation.
  */
 function get_good_images( WP_Post $post ): array {
-	$featured_id   = (int) get_post_thumbnail_id( $post );
-	$featured_file = $featured_id ? pathinfo( (string) get_attached_file( $featured_id ), PATHINFO_FILENAME ) : '';
+	$featured_id       = (int) get_post_thumbnail_id( $post );
+	$featured_file     = $featured_id ? pathinfo( (string) get_attached_file( $featured_id ), PATHINFO_FILENAME ) : '';
+	$featured_metadata = $featured_id ? wp_get_attachment_metadata( $featured_id ) : false;
 
 	if ( ! preg_match_all( '/wp-image-(\d+)/', (string) $post->post_content, $matches ) ) {
 		return array();
+	}
+
+	// Track the byte sizes already represented — seeded with the featured
+	// image — so a re-upload of the same photo is never treated as a distinct
+	// second image. TC names every image in a post from the post slug, so a
+	// re-uploaded featured image lands as a new attachment with a "-2"/"-3"
+	// filename that filename matching can't catch; an identical byte count
+	// (different frames essentially never collide) can.
+	$seen_filesizes = array();
+	if ( is_array( $featured_metadata ) && ! empty( $featured_metadata['filesize'] ) ) {
+		$seen_filesizes[] = (int) $featured_metadata['filesize'];
 	}
 
 	$good = array();
@@ -65,6 +77,16 @@ function get_good_images( WP_Post $post ): array {
 
 		if ( empty( $metadata['width'] ) || empty( $metadata['height'] ) ) {
 			continue;
+		}
+
+		$filesize = ! empty( $metadata['filesize'] ) ? (int) $metadata['filesize'] : 0;
+
+		if ( $filesize > 0 && in_array( $filesize, $seen_filesizes, true ) ) {
+			continue;
+		}
+
+		if ( $filesize > 0 ) {
+			$seen_filesizes[] = $filesize;
 		}
 
 		$good[] = array(

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.10
+ * Version:     0.13.11
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.10",
+	"version": "0.13.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.10",
+			"version": "0.13.11",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.10",
+	"version": "0.13.11",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
Fixes diptychs (and collages) showing the **same photo twice**. TC re-uploads the featured image into article bodies; WordPress gives the copy a new `-2`/`-3` filename derived from the same post slug, so filename matching can't tell it from a genuinely different frame. The block now tracks byte sizes (seeded with the featured image) and skips any content image whose exact filesize is already represented — different frames essentially never collide, so real second photos still qualify. Verified live: Gigi (1795562==1795562) and Zendaya (28813113==28813113) were both dupes; they now fall back to single. Playground: dupe→single, genuine 2nd photo→diptych, content-dupes deduped.