### PR TITLE
image-lightbox: serve a real srcset so gallery images aren't retina-soft (0.13.12)

### DIFF
--- a/blocks/image-lightbox/image-lightbox.php
+++ b/blocks/image-lightbox/image-lightbox.php
@@ -486,33 +486,110 @@ function cata_image_lightbox_caption( string $inner_html ): string {
  */
 function cata_image_lightbox_image_html( array $image ): string {
 
-	if ( $image['id'] ) {
-		$html = wp_get_attachment_image(
-			$image['id'],
-			'large',
-			false,
-			array(
-				'class'    => 'wp-block-cata-image-lightbox__image',
-				// Rendered width inside the panel: 95vw panel minus its padding,
-				// less the ad column and gap once they sit alongside at 1240px,
-				// capped where the panel stops growing.
-				'sizes'    => '(min-width: 1620px) 1150px, (min-width: 1240px) calc(89vw - 304px), calc(95vw - 2rem)',
-				'alt'      => $image['alt'],
-				'loading'  => 'lazy',
-				'decoding' => 'async',
-			)
-		);
+	// Rendered width inside the panel: 95vw panel minus its padding, less the ad
+	// column and gap once they sit alongside at 1240px, capped where the panel
+	// stops growing.
+	$sizes = '(min-width: 1620px) 1150px, (min-width: 1240px) calc(89vw - 304px), calc(95vw - 2rem)';
 
-		if ( '' !== $html ) {
-			return $html;
+	// Resolve the full-size source and the original width so srcset candidates
+	// never claim to be wider than the image the CDN can actually deliver.
+	$base     = $image['src'];
+	$original = 0;
+
+	if ( $image['id'] ) {
+		$full = wp_get_attachment_image_url( $image['id'], 'full' );
+
+		if ( false !== $full ) {
+			$base = $full;
+		}
+
+		$meta = wp_get_attachment_metadata( $image['id'] );
+
+		if ( is_array( $meta ) && ! empty( $meta['width'] ) ) {
+			$original = (int) $meta['width'];
 		}
 	}
 
+	if ( '' === $base ) {
+		return '';
+	}
+
+	$srcset = cata_image_lightbox_srcset( $base, $original );
+
+	// No resizable candidates (e.g. a source the CDN can't resize): serve the
+	// single collected source rather than nothing.
+	if ( '' === $srcset ) {
+		return sprintf(
+			'<img class="wp-block-cata-image-lightbox__image" src="%s" alt="%s" loading="lazy" decoding="async" />',
+			esc_url( $image['src'] ),
+			esc_attr( $image['alt'] )
+		);
+	}
+
 	return sprintf(
-		'<img class="wp-block-cata-image-lightbox__image" src="%s" alt="%s" loading="lazy" decoding="async" />',
-		esc_url( $image['src'] ),
+		'<img class="wp-block-cata-image-lightbox__image" src="%s" srcset="%s" sizes="%s" alt="%s" loading="lazy" decoding="async" />',
+		esc_url( cata_image_lightbox_sized_url( $base, 1280 ) ),
+		esc_attr( $srcset ),
+		esc_attr( $sizes ),
 		esc_attr( $image['alt'] )
 	);
+}
+
+/**
+ * Sized URL
+ *
+ * Point an image URL at a specific rendered width via the CDN's on-demand
+ * resizing, dropping any existing sizing params so only the requested width
+ * applies.
+ *
+ * @param string $url   Image URL.
+ * @param int    $width Target width in pixels.
+ *
+ * @return string
+ */
+function cata_image_lightbox_sized_url( string $url, int $width ): string {
+	$url = remove_query_arg( array( 'w', 'h', 'fit', 'resize', 'crop' ), $url );
+
+	return add_query_arg( 'w', $width, $url );
+}
+
+/**
+ * Srcset
+ *
+ * Build a width-based srcset from one source URL using the CDN's on-demand
+ * resizing. Jetpack/Photon on VIP serves any requested width from the
+ * original, so no intermediate thumbnails need to exist — which is why
+ * wp_get_attachment_image()'s metadata-derived srcset comes back empty here
+ * and the browser was left with a single, retina-soft source. Candidates are
+ * capped at the original width so their descriptors stay honest.
+ *
+ * @param string $url      Full-size image URL.
+ * @param int    $original Original width in pixels, or 0 when unknown.
+ *
+ * @return string Srcset value, or '' when no candidates apply.
+ */
+function cata_image_lightbox_srcset( string $url, int $original ): string {
+
+	$widths = array( 640, 960, 1280, 1600, 2048 );
+
+	// Offer the original itself when it lands between candidates, so the
+	// sharpest honest width is always available.
+	if ( $original > 0 && $original < 2048 && ! in_array( $original, $widths, true ) ) {
+		$widths[] = $original;
+		sort( $widths );
+	}
+
+	$candidates = array();
+
+	foreach ( $widths as $width ) {
+		if ( $original > 0 && $width > $original ) {
+			continue;
+		}
+
+		$candidates[] = esc_url( cata_image_lightbox_sized_url( $url, $width ) ) . ' ' . $width . 'w';
+	}
+
+	return implode( ', ', $candidates );
 }
 
 /**

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.13.11
+ * Version:     0.13.12
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.11",
+	"version": "0.13.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.13.11",
+			"version": "0.13.12",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.13.11",
+	"version": "0.13.12",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
## Problem
Lightbox slides render from a single ~`?w=850` source with **no `srcset`/`sizes`**, so on Retina phones and large desktops they're ~2× undersampled — visibly soft. Since the gallery now only appears on image-rich posts (0.13.10), image quality there is the whole point.

## Why wp_get_attachment_image() didn't fix it
On VIP the CDN (Jetpack/Photon) resizes on demand and stores no intermediate thumbnails, so `wp_calculate_image_srcset()` finds no sizes in the attachment metadata and returns empty — the block silently fell through to the single-source `<img>`.

## Fix
Build the `srcset` directly from CDN width params (`?w=640…2048`) in `cata_image_lightbox_image_html()`, capped at each image's **original width** so the `w` descriptors never overstate what the CDN can deliver. Paired with the existing panel-aware `sizes`. Two small helpers added: `cata_image_lightbox_sized_url()` and `cata_image_lightbox_srcset()`.

## Verification
- Confirmed the CDN honors `?w=` on prod: `?w=1600` → real 1599px image; `?w=2048` correctly caps at a 1992px original.
- Unit-tested the srcset builder (landscape 6000 → up to 2048; portrait 1992 → capped at 1992; small 800 → capped at 800; existing `?w=`/`ssl` params handled).
- PHP linted clean. No build needed — `image-lightbox.php` is loaded directly.
- Will verify on prod post-deploy that `currentSrc` resolves to a large candidate at Retina.

Implements thoughtis/cata-blocks#269. cc @jessica-townsend