### PR TITLE
0.14.2 — query-filters: fix no-results check query swallowing a post

### DIFF
--- a/block-editor/query-filters/query-filters.php
+++ b/block-editor/query-filters/query-filters.php
@@ -243,7 +243,13 @@ function cata_query_filters_exclude_rendered_query_vars( array $query, WP_Block 
 		$query['post__not_in']  = array_values( array_unique( array_merge( $existing, $rendered ) ) );
 	}
 
-	$query['cata_query_filters_register_rendered'] = true;
+	// Only the display loop registers results. Sibling query-builders
+	// (query-no-results, pagination) run CHECK queries with the same vars —
+	// registering those would mark posts as rendered that never displayed,
+	// silently hiding them from every loop below.
+	if ( 'core/post-template' === $block->name ) {
+		$query['cata_query_filters_register_rendered'] = true;
+	}
 
 	return $query;
 }

--- a/cata-blocks.php
+++ b/cata-blocks.php
@@ -12,7 +12,7 @@
  * Description: Block Editor components for use with the Cata theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.14.1
+ * Version:     0.14.2
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cata-blocks",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cata-blocks",
-			"version": "0.14.1",
+			"version": "0.14.2",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cata-blocks",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"description": "Block Editor components for use with the Cata theme.",
 	"scripts": {},
 	"author": "Thought and Expression Co. <devjobs@thought.is>",


### PR DESCRIPTION
Follow-up to #278. `core/query-no-results` runs a check query with the loop's vars; my registration marker applied to it too, so the check's result was recorded as 'rendered' without displaying — hiding one post per flagged query that carries a no-results fallback (live: the day's #2 story vanished from the homepage). Registration is now gated on `core/post-template`; check queries keep the exclusions so their emptiness answer matches the real loop. Playground: hero-shape (perPage 1 + no-results) then grid renders 4/4 posts, no swallow.